### PR TITLE
Changed pwd when running app otherwise folder is locked by spawn process, removing files and folders recursively as root folder may be locked and unable to delete.

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -342,7 +342,8 @@
    */
   function run(path, args, options){
     var opts = {
-      detached: true
+      detached: true,
+      cwd: path
     };
     for(var key in options){
       opts[key] = options[key];
@@ -392,7 +393,23 @@
         }
       }
       function deleteApp(cb){
-        del(to, {force: true}, cb);
+        cb(rmDir(to, false));
+      }
+      function rmDir(dirPath, removeSelf) {
+        if (removeSelf === undefined)
+          removeSelf = true;
+        try { var files = fs.readdirSync(dirPath); }
+        catch(e) { return; }
+        if (files.length > 0)
+          for (var i = 0; i < files.length; i++) {
+            var filePath = dirPath + '/' + files[i];
+            if (fs.statSync(filePath).isFile())
+              fs.unlinkSync(filePath);
+            else
+              rmDir(filePath);
+          }
+        if (removeSelf)
+          fs.rmdirSync(dirPath);
       }
       function appCopied(err){
         if(err){

--- a/app/updater.js
+++ b/app/updater.js
@@ -342,8 +342,7 @@
    */
   function run(path, args, options){
     var opts = {
-      detached: true,
-      cwd: path
+      detached: true
     };
     for(var key in options){
       opts[key] = options[key];
@@ -393,23 +392,8 @@
         }
       }
       function deleteApp(cb){
-        cb(rmDir(to, false));
-      }
-      function rmDir(dirPath, removeSelf) {
-        if (removeSelf === undefined)
-          removeSelf = true;
-        try { var files = fs.readdirSync(dirPath); }
-        catch(e) { return; }
-        if (files.length > 0)
-          for (var i = 0; i < files.length; i++) {
-            var filePath = dirPath + '/' + files[i];
-            if (fs.statSync(filePath).isFile())
-              fs.unlinkSync(filePath);
-            else
-              rmDir(filePath);
-          }
-        if (removeSelf)
-          fs.rmdirSync(dirPath);
+        // in case of path to root folder we want to remove everything from within but root folder as it may be locked
+        del( to + '/**/*', {force: true}, cb);
       }
       function appCopied(err){
         if(err){


### PR DESCRIPTION
- changed delete implementation to not remove root directory as it may be opened (when clicked on nw.exe and kept explorer open) within some program like windows explorer and thus locked. -> it throws error and cannot update
- added run options "cwd" to change working directory to new one as old will be deleted and spawned process will keep lock on folder.
