### PR TITLE
Uncompressed app update fix

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -391,7 +391,7 @@
         }
       }
       function deleteApp(cb){
-        del(to, {force: true}, cb);
+        del(to + '/**/*', {force: true}, cb);
       }
       function appCopied(err){
         if(err){

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -26,7 +26,7 @@ if(gui.App.argv.length) {
         if(!err) {
 
             // ------------- Step 6 -------------
-            upd.run(execPath, null);
+            upd.run(execPath, []);
             gui.App.quit();
         }
     });


### PR DESCRIPTION
When you are using node-webkit-builder with option (zip:false) the update of the Win app fails. These changes will fix this problem
