### PR TITLE
Callback validation into checkNewVersion

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -59,7 +59,12 @@
         return cb(e)
       }
 
-      cb(null, semver.gt(data.version, this.manifest.version), data);
+      try {
+          cb(null, semver.gt(data.version, this.manifest.version), data);
+      } catch (e) {
+          return cb(e)
+      }
+          
     }
   };
 


### PR DESCRIPTION
When app version do not correspond to Semantic Versioning the function semver.gt(...) throw a exception, so, I put the callback into a TryCatch as the others. Now, the developer can know if the version is wrong formatted.