### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Covered by tests and works for [linux](http://screencast.com/t/Je2ptbHhP), [wind
 ## API
 
 <a name="new_updater"></a>
-####new updater(manifest, options)
+#### new updater(manifest, options)
 Creates new instance of updater. Manifest could be a `package.json` of project.
 
 Note that compressed apps are assumed to be downloaded in the format produced by [node-webkit-builder](https://github.com/mllrsohn/node-webkit-builder) (or [grunt-node-webkit-builder](https://github.com/mllrsohn/grunt-node-webkit-builder)).
@@ -40,7 +40,7 @@ Note that compressed apps are assumed to be downloaded in the format produced by
 - options `object` - Optional  
 
 <a name="updater#checkNewVersion"></a>
-####updater.checkNewVersion(cb)
+#### updater.checkNewVersion(cb)
 Will check the latest available version of the application by requesting the manifest specified in `manifestUrl`.
 
 The callback will always be called; the second parameter indicates whether or not there's a newer version.
@@ -51,7 +51,7 @@ This function assumes you use [Semantic Versioning](http://semver.org) and enfor
 - cb `function` - Callback arguments: error, newerVersionExists (`Boolean`), remoteManifest  
 
 <a name="updater#download"></a>
-####updater.download(cb, newManifest)
+#### updater.download(cb, newManifest)
 Downloads the new app to a template folder
 
 **Params**
@@ -61,17 +61,17 @@ Downloads the new app to a template folder
 
 **Returns**: `Request` - Request - stream, the stream contains `manifest` property with new manifest and 'content-length' property with the size of package.  
 <a name="updater#getAppPath"></a>
-####updater.getAppPath()
+#### updater.getAppPath()
 Returns executed application path
 
 **Returns**: `string`  
 <a name="updater#getAppExec"></a>
-####updater.getAppExec()
+#### updater.getAppExec()
 Returns current application executable
 
 **Returns**: `string`  
 <a name="updater#unpack"></a>
-####updater.unpack(filename, cb, manifest)
+#### updater.unpack(filename, cb, manifest)
 Will unpack the `filename` in temporary folder.
 For Windows, [unzip](https://www.mkssoftware.com/docs/man1/unzip.1.asp) is used (which is [not signed](https://github.com/edjafarov/node-webkit-updater/issues/68)).
 
@@ -82,7 +82,7 @@ For Windows, [unzip](https://www.mkssoftware.com/docs/man1/unzip.1.asp) is used 
 - manifest `object`  
 
 <a name="updater#runInstaller"></a>
-####updater.runInstaller(appPath, args, options)
+#### updater.runInstaller(appPath, args, options)
 Runs installer
 
 **Params**
@@ -93,7 +93,7 @@ Runs installer
 
 **Returns**: `function`  
 <a name="updater#install"></a>
-####updater.install(copyPath, cb)
+#### updater.install(copyPath, cb)
 Installs the app (copies current application to `copyPath`)
 
 **Params**
@@ -102,7 +102,7 @@ Installs the app (copies current application to `copyPath`)
 - cb `function` - Callback arguments: error  
 
 <a name="updater#run"></a>
-####updater.run(execPath, args, options)
+#### updater.run(execPath, args, options)
 Runs the app from original app executable path.
 
 **Params**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
